### PR TITLE
Proposed changes for issuer parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Application credentials can be obtained [at Authentiq](https://www.authentiq.com
 Add this line to your application's Gemfile
 
 ```ruby
-gem 'omniauth-authentiq', '~> 0.2.2'
+gem 'omniauth-authentiq', '~> 0.2.5'
 ```
 
 Then bundle:
@@ -20,8 +20,7 @@ Then bundle:
 ```ruby
 use OmniAuth::Builder do
   provider :authentiq, ENV['AUTHENTIQ_KEY'], ENV['AUTHENTIQ_SECRET'],
-           scope: 'aq:name email~rs aq:push',
-           enable_remote_sign_out: false
+           scope: 'aq:name email~rs aq:push'
 end
 ```
 

--- a/lib/omniauth/authentiq/version.rb
+++ b/lib/omniauth/authentiq/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Authentiq
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end

--- a/lib/omniauth/strategies/authentiq.rb
+++ b/lib/omniauth/strategies/authentiq.rb
@@ -5,17 +5,13 @@ module OmniAuth
     class Authentiq < OmniAuth::Strategies::OAuth2
       autoload :BackChannelLogoutRequest, 'omniauth/strategies/oidc/back_channel_logout_request'
 
-      BASE_URL = 'https://connect.authentiq.io/'
-
       option :name, 'authentiq'
 
       option :client_options, {
-          :site => BASE_URL,
-          :authorize_url => '/authorize',
-          :token_url => '/token'
+          :site => 'https://connect.authentiq.io/',
+          :authorize_url => 'https://connect.authentiq.io/authorize',
+          :token_url => 'https://connect.authentiq.io/token'
       }
-
-      option :authorize_options, [:scope]
 
       # These are called after authentication has succeeded. If
       # possible, you should try to set the UID without making

--- a/lib/omniauth/strategies/authentiq.rb
+++ b/lib/omniauth/strategies/authentiq.rb
@@ -1,5 +1,5 @@
 require 'omniauth-oauth2'
-
+require_relative 'helpers/helpers'
 module OmniAuth
   module Strategies
     class Authentiq < OmniAuth::Strategies::OAuth2
@@ -70,8 +70,17 @@ module OmniAuth
       end
 
       def decode_idtoken(idtoken)
-        @jwt_info = JWT.decode idtoken, nil, false
-        @jwt_info[0]
+        (JWT.decode idtoken, @options.client_secret, true, {
+            :algorithm => helpers.algorithm(@options),
+            :iss => @options.client_options.site,
+            :verify_iss => true,
+            :aud => @options.client_id,
+            :verify_aud => true,
+            :verify_iat => true,
+            :verify_jti => false,
+            :verify_sub => true,
+            :leeway => 60
+        })[0]
       end
 
       def should_sign_out?
@@ -86,6 +95,10 @@ module OmniAuth
 
       def backchannel_logout_request
         BackChannelLogoutRequest
+      end
+
+      def helpers
+        Helpers
       end
     end
   end

--- a/lib/omniauth/strategies/helpers/helpers.rb
+++ b/lib/omniauth/strategies/helpers/helpers.rb
@@ -1,0 +1,10 @@
+class Helpers
+  def self.algorithm(options = {})
+    @options = options
+    if @options.algorithm != nil && (%w(HS256 RS256 ES256).include? @options.client_signed_response_alg)
+      @options.client_signed_response_alg
+    else
+      'HS256'
+    end
+  end
+end

--- a/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
+++ b/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
@@ -92,7 +92,7 @@ module OmniAuth
         end
 
         def issuer
-          @options.issuer.nil? ? 'https://connect.authentiq.io/' : @options.issuer
+          @options.client_options.jwt_issuer.nil? ? @options.client_options.site : @options.client_options.jwt_issuer
         end
 
         def algorithm

--- a/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
+++ b/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
@@ -39,7 +39,7 @@ module OmniAuth
           begin
             logout_jwt = JWT.decode logout_token, @options.client_secret, true, {
                 :algorithm => algorithm,
-                :iss => issuer,
+                :iss => @options.client_options.site,
                 :verify_iss => true,
                 :aud => @options.client_id,
                 :verify_aud => true,
@@ -57,9 +57,7 @@ module OmniAuth
         end
 
         def validate_events(logout_jwt)
-          logout_jwt.key?('events') &&
-              (logout_jwt['events'][0] == 'http://schemas.openid.net/event/backchannel-logout' ||
-                  logout_jwt['events'].key?('http://schemas.openid.net/event/backchannel-logout'))
+          logout_jwt.key?('events') && logout_jwt['events'].key?('http://schemas.openid.net/event/backchannel-logout')
         end
 
         def validate_nonce(logout_jwt)
@@ -73,8 +71,6 @@ module OmniAuth
             OmniAuth::logger.send(:warn, 'It look like remote logout is configured on your Authentiq client but \':remote_sign_out_handler\' is not implemented on devise or omniauth')
             raise 'Remote sign out failed because the client\'s \':remote_sign_out_handler\' is not implemented on devise or omniauth'
           end
-
-
         end
 
         def validate_sid(logout_jwt)
@@ -89,10 +85,6 @@ module OmniAuth
           response.headers['Content-Type'] = 'text/plain; charset=utf-8'
           response.body = body
           response
-        end
-
-        def issuer
-          @options.client_options.jwt_issuer.nil? ? @options.client_options.site : @options.client_options.jwt_issuer
         end
 
         def algorithm

--- a/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
+++ b/lib/omniauth/strategies/oidc/back_channel_logout_request.rb
@@ -1,3 +1,5 @@
+require_relative '../helpers/helpers'
+
 module OmniAuth
   module Strategies
     class Authentiq
@@ -38,7 +40,7 @@ module OmniAuth
         def decode_logout_token(logout_token)
           begin
             logout_jwt = JWT.decode logout_token, @options.client_secret, true, {
-                :algorithm => algorithm,
+                :algorithm => helpers.algorithm(@options),
                 :iss => @options.client_options.site,
                 :verify_iss => true,
                 :aud => @options.client_id,
@@ -87,12 +89,8 @@ module OmniAuth
           response
         end
 
-        def algorithm
-          if @options.algorithm != nil && (%w(HS256 RS256 ES256).include? @options.client_signed_response_alg)
-            @options.client_signed_response_alg
-          else
-            'HS256'
-          end
+        def helpers
+          Helpers
         end
       end
     end


### PR DESCRIPTION
- Removed hardcoded issuer url since most of the time is equal to the site option in client options
- In case it under a path (e.g. `https://dev.connect.authentiq.io/backchannel-logout/`) it is declared in the client options like site, token_url, authorize_url with the parameter jwt_issuer.
```yaml
      client_options: {
          :site => 'https://dev.connect.authentiq.io/',
          :authorize_url => '/backchannel-logout/authorize',
          :token_url => '/backchannel-logout/token',
          :jwt_issuer => 'https://dev.connect.authentiq.io/backchannel-logout/'
      }
```
- Bumped version
- Removed `enable_remote_sign_out` from options since now it will be enabled out of the box and notify the implementor if something is going wrong (he forgot to implement the lambda for example)